### PR TITLE
Fixed Diff Keeps Increasing

### DIFF
--- a/src/MiningCore/VarDiff/VarDiffManager.cs
+++ b/src/MiningCore/VarDiff/VarDiffManager.cs
@@ -69,7 +69,7 @@ namespace MiningCore.VarDiff
                 ctx.TimeBuffer.PushBack(sinceLast);
                 ctx.LastTs = ts;
 
-                if (ts - ctx.LastRtc < options.RetargetTime && ctx.TimeBuffer.Size > 0)
+                if (ts - ctx.LastRtc < options.RetargetTime || ctx.TimeBuffer.Size <= 0)
                     return null;
 
                 ctx.LastRtc = ts;


### PR DESCRIPTION
If there is no shares in the retargettime period, the diff will keep increase as the avg becomes 0.
the ddiff will become INF.
Changed to do nothing when the TimeBuffer.Size is 0.