### PR TITLE
VarDiff Bugs Fixed and Redesign

### DIFF
--- a/src/MiningCore/Blockchain/Bitcoin/BitcoinPoolBase.cs
+++ b/src/MiningCore/Blockchain/Bitcoin/BitcoinPoolBase.cs
@@ -145,8 +145,9 @@ namespace MiningCore.Blockchain.Bitcoin
                 client.RespondError(StratumError.NotSubscribed, "Not subscribed", request.Id);
             else
             {
-                UpdateVarDiff(client, manager.BlockchainStats.NetworkDifficulty);
-
+                /* Update VarDiff with Share Submitted. */
+                UpdateVarDiff(client, manager.BlockchainStats.NetworkDifficulty, true);
+                
                 try
                 {
                     // submit 

--- a/src/MiningCore/Util/CircularDoubleBuffer.cs
+++ b/src/MiningCore/Util/CircularDoubleBuffer.cs
@@ -18,14 +18,38 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using MiningCore.Util;
+using System.Linq;
 
-namespace MiningCore.VarDiff
+namespace MiningCore.Util
 {
-    public class VarDiffContext
+    public class CircularDoubleBuffer : CircularBuffer<double>
     {
-        public double LastTs { get; set; }
-        public double LastRtc { get; set; }
-        public CircularDoubleBuffer TimeBuffer { get; set; }
+        public CircularDoubleBuffer(int capacity) : base(capacity)
+        {
+        }
+
+        public CircularDoubleBuffer(int capacity, double[] items) : base(capacity, items)
+        {
+        }
+
+        public double Average()
+        {
+            return ToArray().Average();
+        }
+        
+        public double Sum()
+        {
+            double sum = 0;
+            using (var enumerator = GetEnumerator())
+            {
+                while (enumerator.MoveNext())
+                {
+                    sum += enumerator.Current;
+                }
+            }
+            
+            return sum;
+        }
+        
     }
 }


### PR DESCRIPTION
I hope this PR can help this project. But I am not familiar with C#. Please kindly review my code and optimize it.

1. Cancelled periodic VarDiff updates.
2. Added Timer after each submit for checking if the diff is too high.
3. VarDiffManager always take the current round of submit into account. But will not add the current round until submit. So update can be called any time.
4. Manager will be created once connected.
5. Time will be `double` instead of `long` for accuracy.
6. Avoided using `toArray()`, it seems array copy is not good for performance. just loop the buffer and get the sum.
7. Simplify the coding of calculating newdiff.
 
I have tested the following configs. Everything seems fine.
```
               "difficulty": 128,
                "varDiff": {
                    "minDiff": 8,
                    "maxDiff": null,
                    "targetTime": 30,
                    "retargetTime": 5,
                    "variancePercent": 30
                }
```
```
               "difficulty": 128,
                "varDiff": {
                    "minDiff": 8,
                    "maxDiff": null,
                    "targetTime": 5,
                    "retargetTime": 1,
                    "variancePercent": 30
                }
```
```
               "difficulty": 128,
                "varDiff": {
                    "minDiff": 8,
                    "maxDiff": null,
                    "targetTime": 60,
                    "retargetTime": 60,
                    "variancePercent": 30
                }
```