### PR TITLE
initial signalr integration WIP

### DIFF
--- a/src/MiningCore/Configuration/ClusterConfig.cs
+++ b/src/MiningCore/Configuration/ClusterConfig.cs
@@ -217,6 +217,17 @@ namespace MiningCore.Configuration
         public bool NotifyPaymentSuccess { get; set; }
     }
 
+    public class ApiNotifyConfig
+    {
+        public bool Enabled { get; set; }
+        
+        public bool NotifyAdmin { get; set; }
+        public bool NotifyBlockFound { get; set; }
+        public bool NotifyPaymentSuccess { get; set; }
+        public bool NotifyPaymentFailed { get; set; }
+        
+    }
+
     public partial class SlackNotifications
     {
         public bool Enabled { get; set; }
@@ -257,6 +268,7 @@ namespace MiningCore.Configuration
 
         public EmailSenderConfig Email { get; set; }
         public AdminNotifications Admin { get; set; }
+        public ApiNotifyConfig Api { get; set; }
     }
 
     public partial class ApiConfig

--- a/src/MiningCore/Notifications/SignalR/NotificationsHub.cs
+++ b/src/MiningCore/Notifications/SignalR/NotificationsHub.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.SignalR;
+
+namespace MiningCore.Notifications.SignalR
+{
+    public class NotificationsHub:Hub
+    {
+    }
+}


### PR DESCRIPTION
This PR is not ready!

I'm working on adding a new notification method, a push from server to frontend via Signalr.  I'm a bit stuck since you opted out of using the standard IApplicationBuild and the default Service Collection DI. Not sure where I need to register and configure the SignalR startup. It is usually as follows:
```
    public class Startup
    {
        public void ConfigureServices(IServiceCollection services)
        {
            services.AddSignalR();
        }

        public void Configure(IApplicationBuilder app)
        {
            app.UseSignalR(routes =>
            {
                routes.MapHub<Chat>("chat");
            });
        }
    }
```

How should I go ahead @oliverw 
