### PR TITLE
Add TotalPending property to each pool in API

### DIFF
--- a/src/MiningCore/Api/ApiServer.cs
+++ b/src/MiningCore/Api/ApiServer.cs
@@ -252,6 +252,7 @@ namespace MiningCore.Api
 
                     // enrich
                     result.TotalPaid = cf.Run(con => statsRepo.GetTotalPoolPayments(con, config.Id));
+                    result.TotalPending = cf.Run(con => statsRepo.GetTotalPoolBalances(con, config.Id));
 #if DEBUG
                     var from = new DateTime(2018, 1, 6, 16, 0, 0);
 #else

--- a/src/MiningCore/Api/Responses/GetPoolsResponse.cs
+++ b/src/MiningCore/Api/Responses/GetPoolsResponse.cs
@@ -65,6 +65,7 @@ namespace MiningCore.Api.Responses
         public BlockchainStats NetworkStats { get; set; }
         public MinerPerformanceStats[] TopMiners { get; set; }
         public decimal TotalPaid { get; set; }
+        public decimal TotalPending { get; set; }
     }
 
     public class GetPoolsResponse

--- a/src/MiningCore/Persistence/Postgres/Repositories/StatsRepository.cs
+++ b/src/MiningCore/Persistence/Postgres/Repositories/StatsRepository.cs
@@ -99,6 +99,16 @@ namespace MiningCore.Persistence.Postgres.Repositories
             var result = con.ExecuteScalar<decimal>(query, new { poolId });
             return result;
         }
+        
+        public decimal GetTotalPoolBalances(IDbConnection con, string poolId)
+        {
+            logger.LogInvoke();
+
+            var query = "SELECT sum(amount) FROM balances WHERE poolid = @poolId";
+
+            var result = con.ExecuteScalar<decimal>(query, new { poolId });
+            return result;
+        }
 
         public PoolStats[] GetPoolPerformanceBetweenHourly(IDbConnection con, string poolId, DateTime start, DateTime end)
         {

--- a/src/MiningCore/Persistence/Repositories/IStatsRepository.cs
+++ b/src/MiningCore/Persistence/Repositories/IStatsRepository.cs
@@ -32,6 +32,7 @@ namespace MiningCore.Persistence.Repositories
         void InsertMinerWorkerPerformanceStats(IDbConnection con, IDbTransaction tx, MinerWorkerPerformanceStats stats);
         PoolStats GetLastPoolStats(IDbConnection con, string poolId);
         decimal GetTotalPoolPayments(IDbConnection con, string poolId);
+        decimal GetTotalPoolBalances(IDbConnection con, string poolId);
         PoolStats[] GetPoolPerformanceBetweenHourly(IDbConnection con, string poolId, DateTime start, DateTime end);
         MinerStats GetMinerStats(IDbConnection con, IDbTransaction tx, string poolId, string miner);
         MinerWorkerPerformanceStats[] PagePoolMinersByHashrate(IDbConnection con, string poolId, DateTime from, int page, int pageSize);


### PR DESCRIPTION
Exposes the total pending balances of each pool that has not been paid out as TotalPending, and compliments the TotalPaid stat in the API.