### PR TITLE
Add nextNetworkBits and nextNetworkTarget to /api/pools

### DIFF
--- a/src/Miningcore/Blockchain/Abstractions.cs
+++ b/src/Miningcore/Blockchain/Abstractions.cs
@@ -27,6 +27,8 @@ namespace Miningcore.Blockchain
         public string NetworkType { get; set; }
         public double NetworkHashrate { get; set; }
         public double NetworkDifficulty { get; set; }
+        public string NextNetworkTarget { get; set; }
+        public string NextNetworkBits { get; set; }
         public DateTime? LastNetworkBlockTime { get; set; }
         public ulong BlockHeight { get; set; }
         public int ConnectedPeers { get; set; }

--- a/src/Miningcore/Blockchain/Bitcoin/BitcoinJobManager.cs
+++ b/src/Miningcore/Blockchain/Bitcoin/BitcoinJobManager.cs
@@ -133,6 +133,8 @@ namespace Miningcore.Blockchain.Bitcoin
                             BlockchainStats.LastNetworkBlockTime = clock.Now;
                             BlockchainStats.BlockHeight = blockTemplate.Height;
                             BlockchainStats.NetworkDifficulty = job.Difficulty;
+                            BlockchainStats.NextNetworkTarget = blockTemplate.Target;
+                            BlockchainStats.NextNetworkBits = blockTemplate.Bits;
                         }
 
                         else

--- a/src/Miningcore/Blockchain/Cryptonote/CryptonoteJobManager.cs
+++ b/src/Miningcore/Blockchain/Cryptonote/CryptonoteJobManager.cs
@@ -115,6 +115,8 @@ namespace Miningcore.Blockchain.Cryptonote
                     BlockchainStats.LastNetworkBlockTime = clock.Now;
                     BlockchainStats.BlockHeight = job.BlockTemplate.Height;
                     BlockchainStats.NetworkDifficulty = job.BlockTemplate.Difficulty;
+                    BlockchainStats.NextNetworkTarget = "";
+                    BlockchainStats.NextNetworkBits = "";
                 }
 
                 return isNew;

--- a/src/Miningcore/Blockchain/Equihash/EquihashJobManager.cs
+++ b/src/Miningcore/Blockchain/Equihash/EquihashJobManager.cs
@@ -157,6 +157,8 @@ namespace Miningcore.Blockchain.Equihash
                             BlockchainStats.LastNetworkBlockTime = clock.Now;
                             BlockchainStats.BlockHeight = blockTemplate.Height;
                             BlockchainStats.NetworkDifficulty = job.Difficulty;
+                            BlockchainStats.NextNetworkTarget = blockTemplate.Target;
+                            BlockchainStats.NextNetworkBits = blockTemplate.Bits;
                         }
 
                         else

--- a/src/Miningcore/Blockchain/Ethereum/EthereumJobManager.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumJobManager.cs
@@ -149,6 +149,8 @@ namespace Miningcore.Blockchain.Ethereum
                     BlockchainStats.LastNetworkBlockTime = clock.Now;
                     BlockchainStats.BlockHeight = job.BlockTemplate.Height;
                     BlockchainStats.NetworkDifficulty = job.BlockTemplate.Difficulty;
+                    BlockchainStats.NextNetworkTarget = job.BlockTemplate.Target;
+                    BlockchainStats.NextNetworkBits = "";
                 }
 
                 return isNew;


### PR DESCRIPTION
Adds the bits/target of the next network block to the `pool.networkStats` section of the `api/pools` API

These additional datapoints were necessary for a FLO application but could perhaps be generally useful for debugging or other mining related analysis

Example:
```
      "networkStats": {
        "networkType": "Test",
        "networkHashrate": 10547.259085580305,
        "networkDifficulty": 0.000244137132,
        "nextNetworkTarget": "00000fffff000000000000000000000000000000000000000000000000000000",
        "nextNetworkBits": "1e0fffff",
        "lastNetworkBlockTime": "2018-10-25T15:41:49.5252676Z",
        "blockHeight": 254062,
        "connectedPeers": 16,
        "rewardType": "POW"
      },
```