### PR TITLE
epee: Drop deprecated Boost.Thread header

### DIFF
--- a/src/Native/libcryptonote/contrib/epee/include/syncobj.h
+++ b/src/Native/libcryptonote/contrib/epee/include/syncobj.h
@@ -34,7 +34,7 @@
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/thread/v2/thread.hpp>
+#include <boost/thread/thread.hpp>
 
 namespace epee
 {

--- a/src/Native/libcryptonote/contrib/epee/include/syncobj.h
+++ b/src/Native/libcryptonote/contrib/epee/include/syncobj.h
@@ -35,6 +35,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
+#include <boost/thread/condition_variable.hpp>
 
 namespace epee
 {


### PR DESCRIPTION
Fixes the following build error:

```
  In file included from contrib/epee/include/misc_log_ex.h:36,
                   from contrib/epee/include/include_base_utils.h:32,
                   from cryptonote_basic/cryptonote_format_utils.cpp:31:
  contrib/epee/include/syncobj.h:37:10: fatal error: boost/thread/v2/thread.hpp: No such file or directory
   #include <boost/thread/v2/thread.hpp>
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
  make: *** [<builtin>: cryptonote_basic/cryptonote_format_utils.o] Error 1
```