### PR TITLE
Digibyte Block Explorer Link Fixed

### DIFF
--- a/src/Miningcore/coins.json
+++ b/src/Miningcore/coins.json
@@ -464,7 +464,7 @@
             "hash": "reverse",
             "args": [ { "hash": "sha256d" } ]
         },
-        "explorerBlockLink": "https://digiexplorer.info/block/$height$",
+        "explorerBlockLink": "https://digiexplorer.info/block/$hash$",
         "explorerTxLink": "https://digiexplorer.info/tx/{0}",
         "explorerAccountLink": "https://digiexplorer.info/address/{0}"
     },
@@ -485,7 +485,7 @@
             "args": [ { "hash": "sha256d" } ]
         },
         "shareMultiplier": 65536,
-        "explorerBlockLink": "https://digiexplorer.info/block/$height$",
+        "explorerBlockLink": "https://digiexplorer.info/block/$hash$",
         "explorerTxLink": "https://digiexplorer.info/tx/{0}",
         "explorerAccountLink": "https://digiexplorer.info/address/{0}"
     },
@@ -504,7 +504,7 @@
             "hash": "reverse",
             "args": [ { "hash": "sha256d" } ]
         },
-        "explorerBlockLink": "https://digiexplorer.info/block/$height$",
+        "explorerBlockLink": "https://digiexplorer.info/block/$hash$",
         "explorerTxLink": "https://digiexplorer.info/tx/{0}",
         "explorerAccountLink": "https://digiexplorer.info/address/{0}"
     },
@@ -523,7 +523,7 @@
             "hash": "reverse",
             "args": [ { "hash": "sha256d" } ]
         },
-        "explorerBlockLink": "https://digiexplorer.info/block/$height$",
+        "explorerBlockLink": "https://digiexplorer.info/block/$hash$",
         "explorerTxLink": "https://digiexplorer.info/tx/{0}",
         "explorerAccountLink": "https://digiexplorer.info/address/{0}"
     },
@@ -543,7 +543,7 @@
             "args": [ { "hash": "sha256d" } ]
         },
         "shareMultiplier": 256,
-        "explorerBlockLink": "https://digiexplorer.info/block/$height$",
+        "explorerBlockLink": "https://digiexplorer.info/block/$hash$",
         "explorerTxLink": "https://digiexplorer.info/tx/{0}",
         "explorerAccountLink": "https://digiexplorer.info/address/{0}"
     },
@@ -574,7 +574,7 @@
             }
         },
         "shareMultiplier": 256,
-        "explorerBlockLink": "https://digiexplorer.info/block/$height$",
+        "explorerBlockLink": "https://digiexplorer.info/block/$hash$",
         "explorerTxLink": "https://digiexplorer.info/tx/{0}",
         "explorerAccountLink": "https://digiexplorer.info/address/{0}"
     },


### PR DESCRIPTION
Currently, DGB Block Explorer Link Fails. Fixed by removing `$height$` and adding `$hash$`

Confirmed working on my pool.