### PR TITLE
readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Refer to [this file](https://github.com/coinfoundry/miningcore/blob/master/src/M
 
 #### Monero
 
-- Miningcore utilizes RandomX's light-mode by default which consumes only **256 MB of memory per RandomX-VM**. A mondern (2021) era CPU will be able to handle ~ 50 shares per second in this mode.
+- Miningcore utilizes RandomX's light-mode by default which consumes only **256 MB of memory per RandomX-VM**. A modern (2021) era CPU will be able to handle ~ 50 shares per second in this mode.
 - If you are running into throughput problems on your pool you can either increase the number of RandomX virtual machines in light-mode by adding `"randomXVmCount": x` to your pool configuration where x is at maximum equal to the machine's number of processor cores. Alternatively you can activate fast-mode by adding `"randomXFlagsAdd": "RANDOMX_FLAG_FULL_MEM"` to the pool configuration. Fast mode increases performance by 10x but requires roughly **3 GB of RAM per RandomX-VM**.
 
 #### ZCash


### PR DESCRIPTION
modern instead of mondern

that's it.