### PR TITLE
Update HexToByteArrayJsonConverter.cs

### DIFF
--- a/src/Miningcore/Serialization/HexToByteArrayJsonConverter.cs
+++ b/src/Miningcore/Serialization/HexToByteArrayJsonConverter.cs
@@ -14,7 +14,23 @@ namespace Miningcore.Serialization
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteValue($"0x{value:x}");
+            if(value == null)
+                writer.WriteValue("null");
+            else
+            {
+                // Remove all 0 at the beginning. 0 after 0x is not allowed when the value is not 0
+                object valueToHex = $"{value:x}".TrimStart(new Char[] { '0' });
+                // If value was 0, after trim it is null. Correcting it to 0x0.
+                if(object.Equals(valueToHex, ""))
+                {
+                    writer.WriteValue($"0x{value:x}");
+                }
+                else
+                {
+                    writer.WriteValue($"0x{valueToHex}");
+                }
+            }
+
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
Bug fix: Hex number incorrect
0 after 0x is not allowed when the value is not 0
0x0 = ok
0x078867... 0 after x is not allowed and must be removed