### PR TITLE
Fix Array

### DIFF
--- a/src/Miningcore/Program.cs
+++ b/src/Miningcore/Program.cs
@@ -773,7 +773,7 @@ namespace Miningcore
             }
             .Concat(clusterConfig.CoinTemplates != null ?
                 clusterConfig.CoinTemplates.Where(x => x != defaultTemplates) :
-                new string[0])
+                Array.Empty<string>())
             .ToArray();
 
             return CoinTemplateLoader.Load(container, clusterConfig.CoinTemplates);


### PR DESCRIPTION
Initializing a zero-length array leads to an unnecessary memory allocation.